### PR TITLE
It must reset the @objects before recalculating the linking commands aga...

### DIFF
--- a/lib/cxxproject/buildingblocks/has_sources_mixin.rb
+++ b/lib/cxxproject/buildingblocks/has_sources_mixin.rb
@@ -242,6 +242,7 @@ module Cxxproject
       dirs_with_files = calc_dirs_with_files(sources_to_build)
 
       obj_tasks = []
+      @objects = []
       dirs_with_files.each do |dir, files|
         files.reverse.each do |f|
           obj_task = create_object_file_task(f, sources_to_build[f])


### PR DESCRIPTION
We are reusing, the building blocks in our buildr integration, and if you reuse it you have to reset @objects array before refil it at linking command calculations.
